### PR TITLE
Fix dark theme chat bubble color mismatch with year blocks

### DIFF
--- a/_site/css/style.css
+++ b/_site/css/style.css
@@ -749,8 +749,8 @@ a.no-hover:hover {
 
 @media (prefers-color-scheme: dark) {
   .chat-bubble {
-    background-color: #e9e9eb;
-    color: #1a1a1a;
+    background-color: #2c3034;
+    color: #e9e9e9;
   }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -749,8 +749,8 @@ a.no-hover:hover {
 
 @media (prefers-color-scheme: dark) {
   .chat-bubble {
-    background-color: #e9e9eb;
-    color: #1a1a1a;
+    background-color: #2c3034;
+    color: #e9e9e9;
   }
 }
 


### PR DESCRIPTION
In dark mode, chat bubbles were switching to a light background (#e9e9eb)
while the "Year XXXX" blocks used Bootstrap's bg-dark (#212529), creating
a jarring visual mismatch. Updated chat bubble dark theme color to #2c3034
(consistent with the dark block styling) with matching light text.

https://claude.ai/code/session_01FifKBiU3y78Xx8GCRLe4oF